### PR TITLE
Fixed problem with HashMap caused by Java8 Upgrade

### DIFF
--- a/archetype-validator/src/main/java/org/openehr/am/validation/RMInspector.java
+++ b/archetype-validator/src/main/java/org/openehr/am/validation/RMInspector.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -192,8 +193,8 @@ public class RMInspector {
 				Organisation.class, Person.class, Contact.class,
 				PartyRelationship.class, Role.class, Capability.class };
 
-		typeMap = new HashMap<String, Class>();
-		upperCaseMap = new HashMap<String, Class>();
+		typeMap = new LinkedHashMap<String, Class>();
+		upperCaseMap = new LinkedHashMap<String, Class>();
 		for (Class klass : classes) {
 			String name = klass.getSimpleName();
 			if (klass.getSimpleName().equalsIgnoreCase("Double")) {

--- a/dadl-binding/src/main/java/org/openehr/rm/binding/RMInspector.java
+++ b/dadl-binding/src/main/java/org/openehr/rm/binding/RMInspector.java
@@ -184,8 +184,8 @@ public class RMInspector {
 				Organisation.class, Person.class, Contact.class,
 				PartyRelationship.class, Role.class, Capability.class };
 
-		typeMap = new HashMap<String, Class>();
-		upperCaseMap = new HashMap<String, Class>();
+		typeMap = new LinkedHashMap<String, Class>();
+		upperCaseMap = new LinkedHashMap<String, Class>();
 		for (Class klass : classes) {
 			String name = klass.getSimpleName();
 			typeMap.put(name, klass);

--- a/rm-builder/src/main/java/org/openehr/build/RMObjectBuilder.java
+++ b/rm-builder/src/main/java/org/openehr/build/RMObjectBuilder.java
@@ -162,8 +162,8 @@ public class RMObjectBuilder {
 				Organisation.class, Person.class, Contact.class,
 				PartyRelationship.class, Role.class, Capability.class };
 
-		typeMap = new HashMap<String, Class>();
-		upperCaseMap = new HashMap<String, Class>();
+		typeMap = new LinkedHashMap<String, Class>();
+		upperCaseMap = new LinkedHashMap<String, Class>();
 		for (Class klass : classes) {
 			String name = klass.getSimpleName();
 			typeMap.put(name, klass);

--- a/xml-binding/src/main/java/org/openehr/binding/RMInspector.java
+++ b/xml-binding/src/main/java/org/openehr/binding/RMInspector.java
@@ -180,8 +180,8 @@ public class RMInspector {
 				Organisation.class, Person.class, Contact.class,
 				PartyRelationship.class, Role.class, Capability.class };
 
-		typeMap = new HashMap<String, Class>();
-		upperCaseMap = new HashMap<String, Class>();
+		typeMap = new LinkedHashMap<String, Class>();
+		upperCaseMap = new LinkedHashMap<String, Class>();
 		for (Class klass : classes) {
 			String name = klass.getSimpleName();
 			typeMap.put(name, klass);


### PR DESCRIPTION
Java 8 HashMap were rewritten and don't respect the insert order when you call .keySet() on the HashMap ( From the documentation, order was never guaranteed from the start, it just worked that way ). 
The code uses HashMaps to represent maps where the order of the keys is important.
 