### PR TITLE
Escape quotes in serialized strings

### DIFF
--- a/adl-serializer/src/main/java/org/openehr/am/serialize/ADLSerializer.java
+++ b/adl-serializer/src/main/java/org/openehr/am/serialize/ADLSerializer.java
@@ -14,47 +14,13 @@
  */
 package org.openehr.am.serialize;
 
-import java.io.BufferedOutputStream;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.nio.charset.Charset;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.openehr.am.archetype.Archetype;
 import org.openehr.am.archetype.assertion.Assertion;
-import org.openehr.am.archetype.constraintmodel.ArchetypeInternalRef;
-import org.openehr.am.archetype.constraintmodel.ArchetypeSlot;
-import org.openehr.am.archetype.constraintmodel.CAttribute;
-import org.openehr.am.archetype.constraintmodel.CComplexObject;
-import org.openehr.am.archetype.constraintmodel.CDomainType;
-import org.openehr.am.archetype.constraintmodel.CMultipleAttribute;
-import org.openehr.am.archetype.constraintmodel.CObject;
-import org.openehr.am.archetype.constraintmodel.CPrimitiveObject;
-import org.openehr.am.archetype.constraintmodel.Cardinality;
-import org.openehr.am.archetype.constraintmodel.ConstraintRef;
-import org.openehr.am.archetype.constraintmodel.primitive.CBoolean;
-import org.openehr.am.archetype.constraintmodel.primitive.CDate;
-import org.openehr.am.archetype.constraintmodel.primitive.CDateTime;
-import org.openehr.am.archetype.constraintmodel.primitive.CDuration;
-import org.openehr.am.archetype.constraintmodel.primitive.CInteger;
-import org.openehr.am.archetype.constraintmodel.primitive.CPrimitive;
-import org.openehr.am.archetype.constraintmodel.primitive.CReal;
-import org.openehr.am.archetype.constraintmodel.primitive.CString;
-import org.openehr.am.archetype.constraintmodel.primitive.CTime;
-import org.openehr.am.archetype.ontology.ArchetypeOntology;
-import org.openehr.am.archetype.ontology.ArchetypeTerm;
-import org.openehr.am.archetype.ontology.OntologyBinding;
-import org.openehr.am.archetype.ontology.OntologyDefinitions;
-import org.openehr.am.archetype.ontology.QueryBindingItem;
-import org.openehr.am.archetype.ontology.TermBindingItem;
+import org.openehr.am.archetype.constraintmodel.*;
+import org.openehr.am.archetype.constraintmodel.primitive.*;
+import org.openehr.am.archetype.ontology.*;
 import org.openehr.am.openehrprofile.datatypes.quantity.CDvOrdinal;
 import org.openehr.am.openehrprofile.datatypes.quantity.CDvQuantity;
 import org.openehr.am.openehrprofile.datatypes.quantity.CDvQuantityItem;
@@ -69,6 +35,13 @@ import org.openehr.rm.datatypes.text.CodePhrase;
 import org.openehr.rm.support.basic.Interval;
 import org.openehr.rm.support.identification.ArchetypeID;
 import org.openehr.rm.support.identification.ObjectID;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * ADL serializer for the openEHR Java kernel
@@ -225,9 +198,9 @@ public class ADLSerializer {
 				TranslationDetails td = translations.get(lang);
 				
 				indent(2, out);
-				out.write("[\"");
-				out.write(lang);
-				out.write("\"] = <");				
+				out.write("[");
+				out.write(quoteString(lang));
+				out.write("] = <");
 				newline(out);
 				
 				indent(3, out);
@@ -250,9 +223,9 @@ public class ADLSerializer {
 				
 				if(td.getAccreditation() != null) {
 					indent(3, out);
-					out.write("accreditation = <\"");	
-					out.write(td.getAccreditation());
-					out.write("\">");
+					out.write("accreditation = <");
+					out.write(quoteString(td.getAccreditation()));
+					out.write(">");
 					newline(out);
 				}
 				
@@ -283,11 +256,11 @@ public class ADLSerializer {
 		}
 		for(String key : map.keySet()) {
 			indent(indent, out);
-			out.write("[\"");
-			out.write(key);
-			out.write("\"] = <\"");
-			out.write(map.get(key));
-			out.write("\">");			
+			out.write("[");
+			out.write(quoteString(key));
+			out.write("] = <");
+			out.write(quoteString(map.get(key)));
+			out.write(">");
 			newline(out);
 		}
 	}
@@ -308,7 +281,7 @@ public class ADLSerializer {
 		Map<String, String> map = description.getOriginalAuthor();
 		for (String key : map.keySet()) {
 			indent(2, out);
-			out.write("[\"" + key + "\"] = <\"" + map.get(key) + "\">");
+			out.write("[" + quoteString(key) + "] = <" + quoteString(map.get(key)) + ">");
 			newline(out);
 		}
 		indent(1, out);
@@ -316,9 +289,9 @@ public class ADLSerializer {
 		newline(out);
 
 		indent(1, out);
-		out.write("lifecycle_state = <\"");
-		out.write(description.getLifecycleState());
-		out.write("\">");
+		out.write("lifecycle_state = <");
+		out.write(quoteString(description.getLifecycleState()));
+		out.write(">");
 		newline(out);
 
 		printNonEmptyString("resource_package_uri", description.getResourcePackageUri(), 1, out);
@@ -337,9 +310,9 @@ public class ADLSerializer {
 	protected void printDescriptionItem(ResourceDescriptionItem item,
 			int indent, Writer out) throws IOException {
 		indent(indent, out);
-		out.write("[\"");
-		out.write(item.getLanguage().getCodeString());
-		out.write("\"] = <");
+		out.write("[");
+		out.write(quoteString(item.getLanguage().getCodeString()));
+		out.write("] = <");
 		newline(out);
 
 		indent(indent + 1, out);
@@ -374,9 +347,9 @@ public class ADLSerializer {
 		}
 		indent(indent, out);
 		out.write(label);
-		out.write(" = <\"");
-		out.write(value);
-		out.write("\">");
+		out.write(" = <");
+		out.write(quoteString(value));
+		out.write(">");
 		newline(out);
 	}
 
@@ -390,9 +363,7 @@ public class ADLSerializer {
 		out.write(label);
 		out.write(" = <");
 		for (int i = 0, j = list.size(); i < j; i++) {
-			out.write("\"");
-			out.write(list.get(i));
-			out.write("\"");
+			out.write(quoteString(list.get(i)));
 			if (i != j - 1) {
 				out.write(",");
 			}
@@ -414,7 +385,7 @@ public class ADLSerializer {
 
 		for (String key : map.keySet()) {
 			indent(2, out);
-			out.write("[\"" + key + "\"] = <\"" + map.get(key) + "\">");
+			out.write("[" + quoteString(key) + "] = <" + quoteString(map.get(key)) + ">");
 			newline(out);
 		}
 
@@ -804,14 +775,14 @@ public class ADLSerializer {
 			int index = 1;
 			for (CDvQuantityItem item : list) {
 				indent(indent + 2, out);
-				out.write("[\"");
-				out.write(Integer.toString(index));
-				out.write("\"] = <");
+				out.write("[");
+				out.write(quoteString(Integer.toString(index)));
+				out.write("] = <");
 				newline(out);
 				indent(indent + 3, out);
-				out.write("units = <\"");
-				out.write(item.getUnits());
-				out.write("\">");
+				out.write("units = <");
+				out.write(quoteString(item.getUnits()));
+				out.write(">");
 				newline(out);
 				Interval<Double> value = item.getMagnitude();
 				if (value != null) {
@@ -879,9 +850,9 @@ public class ADLSerializer {
 	}
 	
 	protected void printUnits(String units, Writer out) throws IOException {
-		out.write("units = <\"");
-		out.write(units);
-		out.write("\">");		
+		out.write("units = <");
+		out.write(quoteString(units));
+		out.write(">");
 	}
 
 	protected void printOntology(ArchetypeOntology ontology, Writer out)
@@ -894,9 +865,8 @@ public class ADLSerializer {
 			indent(1, out);
 			out.write("terminologies_available = <");
 			for (String terminology : ontology.getTerminologies()) {
-				out.write("\"");
-				out.write(terminology);
-				out.write("\", ");
+				out.write(quoteString(terminology));
+				out.write(", ");
 			}
 			out.write("...>");
 			newline(out);
@@ -932,9 +902,9 @@ public class ADLSerializer {
 			for (int i = 0; i < ontology.getTermBindingList().size(); i++) {
 				OntologyBinding bind = ontology.getTermBindingList().get(i);
 				indent(2, out);
-				out.write("[\"");
-				out.write(bind.getTerminology());
-				out.write("\"] = <");
+				out.write("[");
+				out.write(quoteString(bind.getTerminology()));
+				out.write("] = <");
 				newline(out);
 				indent(3, out);
 				out.write("items = <");
@@ -946,9 +916,9 @@ public class ADLSerializer {
 							.getTermBindingList().get(i).getBindingList()
 							.get(j);
 					indent(4, out);
-					out.write("[\"");
-					out.write(item.getCode());
-					out.write("\"] = <");
+					out.write("[");
+					out.write(quoteString(item.getCode()));
+					out.write("] = <");
 					out.write(item.getTerms().get(0));
 
 					if (item.getTerms().size() > 1) {
@@ -980,9 +950,9 @@ public class ADLSerializer {
 				OntologyBinding bind = ontology.getConstraintBindingList().get(
 						i);
 				indent(2, out);
-				out.write("[\"");
-				out.write(bind.getTerminology());
-				out.write("\"] = <");
+				out.write("[");
+				out.write(quoteString(bind.getTerminology()));
+				out.write("] = <");
 				newline(out);
 				indent(3, out);
 				out.write("items = <");
@@ -994,9 +964,9 @@ public class ADLSerializer {
 							.getConstraintBindingList().get(i).getBindingList()
 							.get(j);
 					indent(4, out);
-					out.write("[\"");
-					out.write(item.getCode());
-					out.write("\"] = <");
+					out.write("[");
+					out.write(quoteString(item.getCode()));
+					out.write("] = <");
 					out.write(item.getQuery().getUrl());
 					out.write(">");
 					newline(out);
@@ -1013,29 +983,33 @@ public class ADLSerializer {
 		}
 	}
 
-	private void printDefinitionList(Writer out, 
+    private String quoteString(String value) {
+        return "\"" + value.replaceAll("[\"]", "\\\\$0") + "\"";
+    }
+
+	private void printDefinitionList(Writer out,
 			List<OntologyDefinitions> termDefinitionsList) throws IOException {
 		for (OntologyDefinitions defs : termDefinitionsList) {
 			indent(2, out);
-			out.write("[\"");
-			out.write(defs.getLanguage());
-			out.write("\"] = <");
+			out.write("[");
+			out.write(quoteString(defs.getLanguage()));
+			out.write("] = <");
 			newline(out);
 			indent(3, out);
 			out.write("items = <");
 			newline(out);
 			for (ArchetypeTerm term : defs.getDefinitions()) {
 				indent(4, out);
-				out.write("[\"");
-				out.write(term.getCode());
-				out.write("\"] = <");
+				out.write("[");
+				out.write(quoteString(term.getCode()));
+				out.write("] = <");
 				newline(out);
 				for (Map.Entry<String, String> entry : term.getItems().entrySet()) {
 					indent(5, out);
 					out.write(entry.getKey());
-					out.write(" = <\"");
-					out.write(entry.getValue());
-					out.write("\">");
+					out.write(" = <");
+					out.write(quoteString(entry.getValue()));
+					out.write(">");
 					newline(out);
 				}
 				newline(out);
@@ -1184,13 +1158,11 @@ public class ADLSerializer {
 		} else if(cstring.getList() != null){
 			printList(cstring.getList(), out, true);
 		} else if(cstring.defaultValue() != null) {
-			out.write("\"");
-			out.write(cstring.defaultValue());
-			out.write("\"");
+			out.write(quoteString(cstring.defaultValue()));
 		}
 		if(cstring.hasAssumedValue()) {
 			out.write("; ");
-			out.write("\"" + cstring.assumedValue() + "\"");
+			out.write(quoteString(ObjectUtils.toString(cstring.assumedValue(), "")));
 		}
 	}
 
@@ -1204,13 +1176,12 @@ public class ADLSerializer {
 			if (i != 0) {
 				out.write(",");
 			}
+			String item = list.get(i).toString();
 			if (string) {
-				out.write("\"");
-			}
-			out.write(list.get(i).toString());
-			if (string) {
-				out.write("\"");
-			}
+				out.write(quoteString(item));
+			} else {
+			    out.write(item);
+            }
 		}
 	}
 

--- a/adl-serializer/src/main/java/org/openehr/am/serialize/ADLSerializer.java
+++ b/adl-serializer/src/main/java/org/openehr/am/serialize/ADLSerializer.java
@@ -147,7 +147,10 @@ public class ADLSerializer {
 			out.write(adlVersion);
 		}
 		if(uid != null && StringUtils.isNotEmpty(uid.toString())) {
-            out.write("uid=");
+			if (StringUtils.isNotEmpty(adlVersion)) {
+				out.write("; ");
+			}
+			out.write("uid=");
             out.write(uid.toString());
         }
 	    if(StringUtils.isNotEmpty(adlVersion) || (uid!=null &&StringUtils.isNotEmpty(uid.toString()))) {

--- a/adl-serializer/src/test/java/org/openehr/am/serialize/CommonTest.java
+++ b/adl-serializer/src/test/java/org/openehr/am/serialize/CommonTest.java
@@ -26,6 +26,7 @@ import org.openehr.am.archetype.constraintmodel.CAttribute;
 import org.openehr.am.archetype.constraintmodel.Cardinality;
 import org.openehr.rm.support.basic.Interval;
 import org.openehr.rm.support.identification.ArchetypeID;
+import org.openehr.rm.support.identification.HierObjectID;
 
 public class CommonTest extends SerializerTestBase {
 
@@ -45,6 +46,22 @@ public class CommonTest extends SerializerTestBase {
 		verify("archetype\r\n" + "    " + id + "\r\n" + "specialize\r\n"
 				+ "    " + parentId + "\r\n\r\n" + "concept\r\n" + "    ["
 				+ conceptCode + "]\r\n");
+	}
+
+	public void testPrintHeaderAttributes() throws Exception {
+		String id = "openEHR-EHR-EVALUATION.adverse_reaction-medication.v1";
+
+		clean();
+		HierObjectID uid = new HierObjectID("23e1c56c-0a44-11e7-93ae-92361f002671");
+		outputter.printHeader("1.4", new ArchetypeID(id),
+				null, uid, "at0000", out);
+
+		verify("" +
+				"archetype (adl_version=1.4; uid=23e1c56c-0a44-11e7-93ae-92361f002671)\r\n" +
+				"    openEHR-EHR-EVALUATION.adverse_reaction-medication.v1\r\n" +
+				"\r\n" +
+				"concept\r\n" +
+				"    [at0000]\r\n");
 	}
 
 	public void testPrintExistence() throws Exception {

--- a/adl-serializer/src/test/java/org/openehr/am/serialize/StringEscapeTest.java
+++ b/adl-serializer/src/test/java/org/openehr/am/serialize/StringEscapeTest.java
@@ -1,0 +1,61 @@
+package org.openehr.am.serialize;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author markopi
+ */
+public class StringEscapeTest extends SerializerTestBase {
+
+    public void testEscapeMapValues() throws IOException {
+        Map<String, String> map = new LinkedHashMap<String, String>();
+        map.put("at0002", "Characters to escape: \"");
+
+        StringWriter writer = new StringWriter();
+        outputter.printMap(map, writer, 0);
+        String serialized = writer.toString().trim();
+
+        assertEquals("[\"at0002\"] = <\"Characters to escape: \\\"\">", serialized);
+    }
+
+    public void testEscapeMapKeys() throws IOException {
+        Map<String, String> map = new LinkedHashMap<String, String>();
+        map.put("term\"inology", "Terminology");
+
+        StringWriter writer = new StringWriter();
+        outputter.printMap(map, writer, 0);
+        String serialized = writer.toString().trim();
+
+        assertEquals("[\"term\\\"inology\"] = <\"Terminology\">", serialized);
+    }
+
+    public void testEscapeStringList() throws IOException {
+        List<String> list = new ArrayList<String>();
+        list.add("Escape: \"");
+        list.add("Other");
+
+        StringWriter writer = new StringWriter();
+        outputter.printList(list, writer, true);
+        String serialized = writer.toString().trim();
+
+        assertEquals("\"Escape: \\\"\",\"Other\"", serialized);
+    }
+
+    public void testKeepNonStringList() throws IOException {
+        List<Integer> list = new ArrayList<Integer>();
+        list.add(1);
+        list.add(2);
+
+        StringWriter writer = new StringWriter();
+        outputter.printList(list, writer, false);
+        String serialized = writer.toString().trim();
+
+        assertEquals("1,2", serialized);
+    }
+
+}


### PR DESCRIPTION
Also added a delimiter when both adl_version and uid are present in archetype header