### PR TITLE
initial commit

### DIFF
--- a/oet-parser/src/main/java/org/openehr/am/template/Flattener.java
+++ b/oet-parser/src/main/java/org/openehr/am/template/Flattener.java
@@ -1265,7 +1265,8 @@ public class Flattener {
 			if(valueAttr != null) {
 				valueAttr.removeAllChildren();
 				CDvQuantity cdq = CDvQuantity.singleRequired(valuePath, item);
-				valueAttr.addChild(cdq);	
+				valueAttr.addChild(cdq);
+				return;
 			}
 			
 		} else if(includedUnits != null && includedUnits.length == 1) {


### PR DESCRIPTION
When having a single unitMagnitude as in

```
<Rule path="/data[at0001]/events[at0002]/data[at0003]/items[at0004]">
    <constraint xsi:type="tem:quantityConstraint">
        <excludedUnits>[in_i]</excludedUnits>
        <unitMagnitude>
            <unit>cm</unit>
            <maxMagnitude>1000.0</maxMagnitude>
            <minMagnitude>0.0</minMagnitude>
            <includesMaximum>true</includesMaximum>
            <includesMinimum>true</includesMinimum>
        </unitMagnitude>
    </constraint>
</Rule>
```
The code would add the unit-magnitude in the appropriate if-block but also at the end of the method, meaning the same unit-magnitude is added twice. 

This fix simply returns in the if-block to avoid this behavior.